### PR TITLE
fixed dependency on activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'rdoc', '~> 4.2'
 gem 'coveralls', '~> 0.8.10', require: false
 
 group :test do
+  gem 'memcache_mock'
+  gem 'mock_redis'
   gem 'rspec', '~> 3.1'
   gem 'rspec-core', '~> 3.1'
   gem 'rspec-mocks', '~> 3.1'

--- a/lib/tml/cache.rb
+++ b/lib/tml/cache.rb
@@ -41,7 +41,9 @@ module Tml
   def self.cache
     @cache ||= begin
       if Tml.config.cache_enabled?
-        klass = Tml::CacheAdapters.const_get(Tml.config.cache[:adapter].to_s.camelcase)
+        # .capitalize is not ideal, but .camelcase is not available in pure ruby.
+        # This works for the current class names.
+        klass = Tml::CacheAdapters.const_get(Tml.config.cache[:adapter].to_s.capitalize)
         klass.new
       else
         # blank implementation

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -2,6 +2,18 @@
 
 require 'spec_helper'
 
+# mock the Cache Adapters tested below
+require 'mock_redis'
+class Redis < MockRedis ; end
+require 'memcache_mock'
+module Dalli
+  class Client < MemcacheMock
+    def initialize(*args)
+      super()
+    end
+  end
+end
+
 describe Tml::Cache do
   describe "#initialize" do
     it "features" do
@@ -10,6 +22,33 @@ describe Tml::Cache do
 
       Tml.cache.info('Test')
       Tml.cache.warn('Test')
+    end
+  end
+
+  describe "Cache Adapters" do
+    around(:each) do |example|
+      # save and restore the original cache
+      original_cache = Tml.cache
+      Tml.instance_variable_set(:@cache, nil)
+      example.run
+      Tml.instance_variable_set(:@cache, original_cache)
+    end
+
+
+    it 'returns a file cache' do
+      tempfile = Tempfile.new('cache.dat')
+      allow(Tml.config).to receive(:cache).and_return({adapter: 'file', path: tempfile.path})
+      expect(Tml.cache).to be_kind_of(Tml::CacheAdapters::File)
+    end
+
+    it 'returns a memcache cache' do
+      allow(Tml.config).to receive(:cache).and_return({adapter: 'memcache'})
+      expect(Tml.cache).to be_kind_of(Tml::CacheAdapters::Memcache)
+    end
+
+    it 'returns a redis cache' do
+      allow(Tml.config).to receive(:cache).and_return({adapter: 'redis'})
+      expect(Tml.cache).to be_kind_of(Tml::CacheAdapters::Redis)
     end
   end
 end


### PR DESCRIPTION
We hit a snag when testing the cache. There is a hidden dependency on ActiveSupport so this fixes it.

I added some sample code to mock redis and memcache adapters that may prove useful for testing those adapter classes more thoroughly. I would refactor them into a shared location if you do.
