### PR TITLE
added tasks to gemspec

### DIFF
--- a/tml.gemspec
+++ b/tml.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |gem|
   gem.summary     = 'Tml Core Classes'
   gem.description = 'Tml core classes that can be used by any Ruby framework'
 
-  gem.files       = Dir['{lib,config}/**/*'] + %w(LICENSE Rakefile README.md)
+  gem.files       = Dir['{lib,config,tasks}/**/*'] + %w(LICENSE Rakefile README.md)
   gem.licenses    = 'MIT-LICENSE'
 
   gem.add_dependency 'faraday', '~> 0.8'


### PR DESCRIPTION
When I gem install the 5.4.2 version the 'tasks' directory didn't come along with it. I think that was the intent. This should fix it, but I don't publish enough gems myself to know for sure.
