### PR TITLE
fix String#last usage in get_cdn_path

### DIFF
--- a/lib/tml/api/client.rb
+++ b/lib/tml/api/client.rb
@@ -129,7 +129,8 @@ class Tml::Api::Client < Tml::Base
 
   def get_cdn_path(key, opts = {})
     base_path = URI(application.cdn_host).path
-    base_path += '/' unless base_path.last == '/'
+    # Remove usage of String#last for clients who do not use ActiveSupport
+    base_path += '/' unless base_path.size > 0 && base_path[-1..-1] == '/'
 
     adjusted_path = "#{base_path}#{application.key}/"
 

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -47,4 +47,22 @@ describe Tml::Api::Client do
       end
     end
   end
+
+  describe 'get_cdn_path' do
+    before { allow(application).to receive(:key).and_return('abc_123') }
+
+    context 'no slash in url' do
+      before { allow(application).to receive(:cdn_host).and_return('www.example.com') }
+      it { expect(client.get_cdn_path('version')).to eq 'www.example.com/abc_123/version.json' }
+    end
+
+    context 'slash in base path' do
+      before { allow(application).to receive(:cdn_host).and_return('www.example.com/') }
+      it { expect(client.get_cdn_path('version')).to eq 'www.example.com/abc_123/version.json' }
+    end
+
+    context 'no base_path' do
+      it { expect(client.get_cdn_path('version')).to eq '/abc_123/version.json' }
+    end
+  end
 end


### PR DESCRIPTION
This fixes the usage of non Ruby standard lib String#last for clients that use this gem in environments that do not include ActiveSupport. This is roughly based on https://apidock.com/rails/String/last